### PR TITLE
Reject NULL / uninitialised mutex handles with EINVAL

### DIFF
--- a/pthread_mutex_destroy.c
+++ b/pthread_mutex_destroy.c
@@ -55,8 +55,16 @@ pthread_mutex_destroy (pthread_mutex_t * mutex)
   pthread_mutex_t mx;
 
   /*
-   * Let the system deal with invalid pointers.
+   * Reject NULL / uninitialised mutexes explicitly. Most embedded
+   * targets this library runs on don't have signal handling for bad
+   * loads — a NULL deref traps straight into the kernel rather than
+   * surfacing an error to the caller, so the OS layer cannot be
+   * relied on to validate the pointer for us.
    */
+  if (mutex == NULL || *mutex == NULL)
+    {
+      return EINVAL;
+    }
 
   /*
    * Check to see if we have something to delete.

--- a/pthread_mutex_lock.c
+++ b/pthread_mutex_lock.c
@@ -54,9 +54,13 @@ pthread_mutex_lock (pthread_mutex_t * mutex)
   pthread_mutex_t mx;
 
   /*
-   * Let the system deal with invalid pointers.
+   * Reject NULL / uninitialised mutexes explicitly. Most embedded
+   * targets this library runs on don't have signal handling for bad
+   * loads — a NULL deref traps straight into the kernel rather than
+   * surfacing an error to the caller, so the OS layer cannot be
+   * relied on to validate the pointer for us.
    */
-  if (*mutex == NULL)
+  if (mutex == NULL || *mutex == NULL)
     {
       return EINVAL;
     }

--- a/pthread_mutex_timedlock.c
+++ b/pthread_mutex_timedlock.c
@@ -115,8 +115,16 @@ pthread_mutex_timedlock (pthread_mutex_t * mutex,
   pthread_mutex_t mx;
 
   /*
-   * Let the system deal with invalid pointers.
+   * Reject NULL / uninitialised mutexes explicitly. Most embedded
+   * targets this library runs on don't have signal handling for bad
+   * loads — a NULL deref traps straight into the kernel rather than
+   * surfacing an error to the caller, so the OS layer cannot be
+   * relied on to validate the pointer for us.
    */
+  if (mutex == NULL || *mutex == NULL)
+    {
+      return EINVAL;
+    }
 
   /*
    * We do a quick check to see if we need to do more work

--- a/pthread_mutex_trylock.c
+++ b/pthread_mutex_trylock.c
@@ -51,8 +51,16 @@ pthread_mutex_trylock (pthread_mutex_t * mutex)
   pthread_mutex_t mx;
 
   /*
-   * Let the system deal with invalid pointers.
+   * Reject NULL / uninitialised mutexes explicitly. Most embedded
+   * targets this library runs on don't have signal handling for bad
+   * loads — a NULL deref traps straight into the kernel rather than
+   * surfacing an error to the caller, so the OS layer cannot be
+   * relied on to validate the pointer for us.
    */
+  if (mutex == NULL || *mutex == NULL)
+    {
+      return EINVAL;
+    }
 
   /*
    * We do a quick check to see if we need to do more work

--- a/pthread_mutex_unlock.c
+++ b/pthread_mutex_unlock.c
@@ -58,8 +58,16 @@ pthread_mutex_unlock (pthread_mutex_t * mutex)
   pthread_mutex_t mx;
 
   /*
-   * Let the system deal with invalid pointers.
+   * Reject NULL / uninitialised mutexes explicitly. Most embedded
+   * targets this library runs on don't have signal handling for bad
+   * loads — a NULL deref traps straight into the kernel rather than
+   * surfacing an error to the caller, so the OS layer cannot be
+   * relied on to validate the pointer for us.
    */
+  if (mutex == NULL || *mutex == NULL)
+    {
+      return EINVAL;
+    }
 
   mx = *mutex;
 

--- a/tests/mutex9.c
+++ b/tests/mutex9.c
@@ -1,0 +1,96 @@
+/*
+ * mutex9.c
+ *
+ *
+ * --------------------------------------------------------------------------
+ *
+ *      Pthreads-embedded (PTE) - POSIX Threads Library for embedded systems
+ *      Copyright(C) 2008 Jason Schmidlapp
+ *
+ *      Contact Email: jschmidlapp@users.sourceforge.net
+ *
+ *
+ *      Based upon Pthreads-win32 - POSIX Threads Library for Win32
+ *      Copyright(C) 1998 John E. Bossom
+ *      Copyright(C) 1999,2005 Pthreads-win32 contributors
+ *
+ *      Contact Email: rpj@callisto.canberra.edu.au
+ *
+ *      The original list of contributors to the Pthreads-win32 project
+ *      is contained in the file CONTRIBUTORS.ptw32 included with the
+ *      source code distribution. The list can also be seen at the
+ *      following World Wide Web location:
+ *      http://sources.redhat.com/pthreads-win32/contributors.html
+ *
+ *      This library is free software; you can redistribute it and/or
+ *      modify it under the terms of the GNU Lesser General Public
+ *      License as published by the Free Software Foundation; either
+ *      version 2 of the License, or (at your option) any later version.
+ *
+ *      This library is distributed in the hope that it will be useful,
+ *      but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *      Lesser General Public License for more details.
+ *
+ *      You should have received a copy of the GNU Lesser General Public
+ *      License along with this library in the file COPYING.LIB;
+ *      if not, write to the Free Software Foundation, Inc.,
+ *      59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+ *
+ * --------------------------------------------------------------------------
+ *
+ * Every mutex API must reject NULL / uninitialised handles with EINVAL
+ * rather than dereferencing them. On hosted targets a bad load would
+ * raise SIGSEGV; on the embedded targets this library runs on the
+ * kernel traps and the process dies, so the API itself has to validate
+ * the pointer. This guards against the case where a caller ignored an
+ * ENOMEM return from pthread_mutex_init and the mutex value stayed
+ * NULL, plus the simpler case of forgetting to call init at all.
+ *
+ * Depends on API functions:
+ *      pthread_mutex_lock()
+ *      pthread_mutex_trylock()
+ *      pthread_mutex_timedlock()
+ *      pthread_mutex_unlock()
+ *      pthread_mutex_destroy()
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <time.h>
+
+#include "test.h"
+
+
+int
+pthread_test_mutex9()
+{
+  /* Uninitialised mutex variable (zero-initialised by C, so == NULL). */
+  pthread_mutex_t mutex = NULL;
+  struct timespec abstime = { 0, 0 };
+
+  /* Passing a NULL pointer-to-mutex must give EINVAL, not crash. */
+  assert(pthread_mutex_lock(NULL) == EINVAL);
+  assert(pthread_mutex_trylock(NULL) == EINVAL);
+  assert(pthread_mutex_timedlock(NULL, &abstime) == EINVAL);
+  assert(pthread_mutex_unlock(NULL) == EINVAL);
+  assert(pthread_mutex_destroy(NULL) == EINVAL);
+
+  /* A valid pointer to a NULL-valued mutex (init failed or skipped)
+   * must also give EINVAL — this is the case that used to crash on
+   * targets without signal handling for bad loads.
+   */
+  assert(mutex == NULL);
+  assert(pthread_mutex_lock(&mutex) == EINVAL);
+  assert(pthread_mutex_trylock(&mutex) == EINVAL);
+  assert(pthread_mutex_timedlock(&mutex, &abstime) == EINVAL);
+  assert(pthread_mutex_unlock(&mutex) == EINVAL);
+  assert(pthread_mutex_destroy(&mutex) == EINVAL);
+
+  /* The mutex value must remain NULL after rejection — the API must
+   * not have written through the pointer on the error path. */
+  assert(mutex == NULL);
+
+  return 0;
+}

--- a/tests/test.h
+++ b/tests/test.h
@@ -148,6 +148,8 @@ int pthread_test_mutex8e();
 int pthread_test_mutex8n();
 int pthread_test_mutex8r();
 
+int pthread_test_mutex9();
+
 int pthread_test_valid1();
 int pthread_test_valid2();
 

--- a/tests/test_main.c
+++ b/tests/test_main.c
@@ -258,6 +258,9 @@ static void runMutexTests(void)
   printf("Mutex test #8r\n");
   pthread_test_mutex8r();
 
+  printf("Mutex test #9 (NULL / uninitialised handles)\n");
+  pthread_test_mutex9();
+
 }
 
 static void runSpinTests()


### PR DESCRIPTION
## Summary
- Make `pthread_mutex_{lock,trylock,timedlock,unlock,destroy}` reject `mutex == NULL` and `*mutex == NULL` with `EINVAL` instead of dereferencing.
- The previous code relied on the OS to convert a bad load into an error. On the embedded targets this library runs on (PS2 EE, PSP, Vita) there is no signal handling for bad loads — the kernel traps and the process dies, so the API itself has to validate the pointer.
- Add `tests/mutex9.c` exercising both NULL handles and the post-failed-init NULL-value case across all five mutex APIs.

## Test plan
- [ ] Build the test suite for PS2 and confirm `pthread_test_mutex9()` passes.
- [ ] Build the test suite for PSP and confirm `pthread_test_mutex9()` passes.
- [ ] Confirm existing mutex tests (1..8r) still pass on both targets.